### PR TITLE
Fix Sass syntax error

### DIFF
--- a/src/styles/themes/default.scss
+++ b/src/styles/themes/default.scss
@@ -131,7 +131,7 @@ $primary-color: #919292;
 }
 
 @keyframes loading {
-  0 {
+  0% {
     transform: translate(0, 0);
     background-color: lighten($primary-color, 10%);
   }


### PR DESCRIPTION
> Invalid CSS after "": expected keyframes selector (e.g. 10%), was "0"