### PR TITLE
Fix human messages layout

### DIFF
--- a/src/styles/botui.scss
+++ b/src/styles/botui.scss
@@ -25,6 +25,12 @@
 .botui-message {
   margin: 10px 0;
   min-height: 20px;
+  
+  &:after {
+    display: block;
+    content: "";
+    clear: both;
+  }
 }
 
 .botui-message-content {


### PR DESCRIPTION
As human messages are floated, the `botui-message` container did not expand to fit the message content height. That caused this layout breakage:
![image](https://user-images.githubusercontent.com/1577810/34607381-8d3f175a-f213-11e7-902b-f2acda2c8df1.png)

Now, with the clearfix, it looks like this:
![image](https://user-images.githubusercontent.com/1577810/34607393-a1d2f2c2-f213-11e7-8d72-0b0fae7e4443.png)
