### PR TITLE
Fix multiline buttons layout

### DIFF
--- a/src/styles/botui.scss
+++ b/src/styles/botui.scss
@@ -52,9 +52,11 @@
   text-decoration: underline;
 }
 
-.botui-actions-buttons-button {
-  & + .botui-actions-buttons-button {
-    margin-left: 10px;
+button.botui-actions-buttons-button {
+  margin-bottom: 10px;
+
+  &:not(:last-child) {
+    margin-right: 10px;
   }
 }
 


### PR DESCRIPTION
When a collection of buttons splits into more than one line, margins make it look ugly like this:
![captura de pantalla 2018-01-05 a las 16 57 33](https://user-images.githubusercontent.com/1577810/34617228-fecca190-f23a-11e7-9800-8dbf2fc98e72.png)

So I added a `margin-bottom` and `right-margin` instead of `left-margin`. Now it looks like this:
![captura de pantalla 2018-01-05 a las 16 56 39](https://user-images.githubusercontent.com/1577810/34617255-1b124170-f23b-11e7-8e67-2c1711fb55fa.png)
