### PR TITLE
Scroll down fix for bot markdown messages

### DIFF
--- a/src/botui.html
+++ b/src/botui.html
@@ -3,7 +3,7 @@
     <div v-for="msg in messages" class="botui-message" :class="msg.cssClass" v-botui-scroll>
       <transition name="slide-fade">
         <div v-if="msg.visible" :class="[{human: msg.human, 'botui-message-content': true}, msg.type]">
-          <span v-if="msg.type == 'text'" v-text="msg.content" v-botui-markdown></span>
+          <span v-if="msg.type == 'text'" v-text="msg.content" v-botui-markdown v-botui-scroll></span>
           <iframe v-if="msg.type == 'embed'" :src="msg.content" frameborder="0" allowfullscreen></iframe>
         </div>
       </transition>


### PR DESCRIPTION
Hey guys, really great project! I have had a ton of fun implementing in my own work. Apologies if this is a silly pull request, my background is in Python and my understanding of Javascript is very limited (Vue I just started reading the docs on last night) but I found that my chat ui window was not scrolling down when the bot's chat (human : false) was multi-lined. This lead to inconvenient use (who wants to have to scroll down to read a message). Adding v-botui-scroll to text type messages seemed to do the trick.

Again, I do not fully understand Vue so this might be a naive implementation of the functionality I was trying to create but it seems to work and I could see other people desiring the same functionality so I figured I would create the pull request. Thanks!