### PR TITLE
New action buttontext, with both button and text shown

### DIFF
--- a/src/botui.html
+++ b/src/botui.html
@@ -41,6 +41,30 @@
              {{button.text}}
           </button>
         </div>
+        <form v-if="action.type == 'buttontext'" class="botui-actions-text" 
+          @submit.prevent="handle_action_text()" :class="action.cssClass">
+          <i v-if="action.text.icon" 
+          class="botui-icon botui-action-text-icon fa" 
+          :class="'fa-' + action.text.icon"></i>
+          <input type="text" ref="input" :type="action.text.sub_type" 
+          v-model="action.text.value" class="botui-actions-text-input" :placeholder="action.text.placeholder"
+          :size="action.text.size" :value="action.text.value" :class="action.text.cssClass" required v-focus />
+          <button type="submit" 
+            :class="{'botui-actions-buttons-button': !!action.text.button, 'botui-actions-text-submit': !action.text.button}">
+            <i v-if="action.text.button && action.text.button.icon" class="botui-icon botui-action-button-icon fa"
+            :class="'fa-' + action.text.button.icon"></i>
+            <span>{{(action.text.button && action.text.button.label) || 'Go'}}</span>
+          </button>
+          <div class="botui-actions-buttons" :class="action.cssClass">
+            <button type="button" :class="button.cssClass" 
+              class="botui-actions-buttons-button" v-for="button in action.button.buttons" 
+              @click="handle_action_button(button)" 
+              autofocus>
+              <i v-if="button.icon" class="botui-icon botui-action-button-icon fa" :class="'fa-' + button.icon"></i>
+               {{button.text}}
+            </button>
+          </div>            
+        </form>          
       </div>
     </transition>
   </div>

--- a/src/scripts/botui.js
+++ b/src/scripts/botui.js
@@ -249,7 +249,7 @@
     }
 
     function _checkAction(_opts) {
-      if(!_opts.action) {
+      if(!_opts.action && !_opts.actionButton  && !_opts.actionText) {
         throw Error('BotUI: "action" property is required.');
       }
     }
@@ -294,7 +294,14 @@
         _opts.type = 'button';
         _instance.action.button.buttons = _opts.action;
         return _showActions(_opts);
-      }
+      },
+      buttontext: function (_opts) {
+        _checkAction(_opts);
+        _opts.type = 'buttontext';
+        _instance.action.button.buttons = _opts.actionButton;
+        _instance.action.text = _opts.actionText;
+        return _showActions(_opts);
+      }      
     };
 
     if(_options.fontawesome) {


### PR DESCRIPTION
This code aims to Closes #50 by adding an another action called buttontext (issue created by myself).

Now we can create messages like this:

![image](https://user-images.githubusercontent.com/1680085/38462651-2aea9592-3ac1-11e8-8bff-95fd372ccbc1.png)

With a simple object structure that is just a merge from both "action text" and "action button" passed to botui.

```
var botui = new BotUI('hello-world');

botui.message.add({
  content: 'What would you like to do?!'
});

botui.action.buttontext({
  'addMessage': true,
  'autoHide': false,
  'actionButton': [ 
    { 
    'text': 'Check temperature', 
    'value': 'Check' 
    },
    { 
      'text': 'Change temperature', 
      'value': 'Change' 
    },    
  ],
  'actionText': { 'placeholder': 'Enter the temperature' }
});
```

The CSS may be changed to this as well:

```
button.botui-actions-buttons-button,
input.botui-actions-text-input {
  margin: 5px;
```