### PR TITLE
export declared types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@
  * 
  * @interface BotUIOptions
  */
-interface BotUIOptions {
+export interface BotUIOptions {
     /**
      * Set this to true if you want to debug the underlaying Vue instance
      * 
@@ -29,7 +29,7 @@ interface BotUIOptions {
  * 
  * @interface MessageOption
  */
-interface MessageOption {
+export interface MessageOption {
     /**
      * Set to true if you want to show a loading state '3 animated dots'. 
      * Available in version >= 0.3.1
@@ -81,7 +81,7 @@ interface MessageOption {
  * 
  * @interface ActionsOption
  */
-interface BaseActionsOption {
+export interface BaseActionsOption {
     /**
      * Either 'text' or 'button'.
      * 
@@ -124,7 +124,7 @@ interface BaseActionsOption {
  * 
  * @interface TextObject
  */
-interface TextObject {
+export interface TextObject {
     /**
      * Size of the input to show. Relies on HTML size attribute for input elements.
      * 
@@ -160,7 +160,7 @@ interface TextObject {
  * 
  * @interface ButtonObject
  */
-interface ButtonObject {
+export interface ButtonObject {
     /**
      * Icon to show in button.
      * 
@@ -191,11 +191,11 @@ interface ButtonObject {
     cssClass?: string | string[];
 }
 
-interface TextActionOption extends BaseActionsOption {
+export interface TextActionOption extends BaseActionsOption {
     action: TextObject;
 }
 
-interface ButtonActionOption extends BaseActionsOption {
+export interface ButtonActionOption extends BaseActionsOption {
     action: ButtonObject[];
 }
 
@@ -204,7 +204,7 @@ interface ButtonActionOption extends BaseActionsOption {
  * 
  * @interface ResultObject
  */
-interface ResultObject {
+export interface ResultObject {
     /**
      * 'Text' or 'Button' Type of the action it was returned from.
      * 
@@ -228,7 +228,7 @@ interface ResultObject {
     text: string;
 }
 
-declare class BotUI {
+export declare class BotUI {
 
 
     constructor(id: string, opts?: BotUIOptions);


### PR DESCRIPTION
Importing the botui module to a typescript project causes compile errors because of missing 'export' keywords on declared types in the type defintions file. 

Added theese mssing export statements.