### PR TITLE
Fix Promise error in IE11

### DIFF
--- a/src/scripts/botui.js
+++ b/src/scripts/botui.js
@@ -53,7 +53,7 @@
       }
     }
 
-    if(!root.Promise && !Promise && !options.promise) {
+    if(!root.Promise && typeof Promise === "undefined" && !opts.promise) {
       loadScript(_esPromisePollyfill);
     }
 


### PR DESCRIPTION
In IE11, current version gives an error about "Promise" being undefined.