### PR TITLE
Bug fix: Error loading http icon image.

### DIFF
--- a/src/styles/botui.scss
+++ b/src/styles/botui.scss
@@ -72,7 +72,7 @@
 }
 .profil > img {
   &.agent {
-    content: url(https://i.imgur.com/ntN4XQg.png);
+    content: url(https://github.com/botui/botui/raw/master/logo.svg);
     border-radius: 50%;
   }
   width: 26px;

--- a/src/styles/botui.scss
+++ b/src/styles/botui.scss
@@ -72,7 +72,7 @@
 }
 .profil > img {
   &.agent {
-    content: url(http://decodemoji.com/img/logos/blue_moji_hat.svg);
+    content: url(https://i.imgur.com/ntN4XQg.png);
     border-radius: 50%;
   }
   width: 26px;


### PR DESCRIPTION
I encounter a problem that the bot icon won't load on my website. 

`Mixed Content: The page at 'https://blinkchan.github.io/' was loaded over HTTPS, but requested an insecure image 'http://ww12.decodemoji.com/'. This content should also be served over HTTPS.`

After some research I found that this css file will load a image with HTTP. Should use a HTTPS image instead.

